### PR TITLE
docs: Add documentation for GitHub Actions and Docker image builds

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,10 +1,10 @@
-# Base and R2DT Docker Images
+# Docker images
 
 ## Overview
 
-This project uses a combination of two Docker images: `base_image` and the R2DT image. The `base_image` contains all non-Python dependencies of R2DT, while the R2DT image includes the necessary Python packages.
+This project uses a combination of two Docker images: `base_image` and the R2DT image. The `base_image` contains all non-Python dependencies of R2DT, while the R2DT image includes the necessary Python packages. The images are built and pushed to Docker Hub using [GitHub Actions](./github-actions.md).
 
-## Base Image
+## Base image
 
 The build process for the base image is detailed in [base_image/Dockerfile](https://github.com/r2dt-bio/R2DT/blob/main/base_image/Dockerfile). It uses GCC to compile C/C++ code and installs additional dependencies, such as Perl-related tools.
 
@@ -14,15 +14,15 @@ Rebuilding the base image is rare and is necessary only when an R2DT dependency 
 
 View [rnacentral/r2dt-base](https://hub.docker.com/r/rnacentral/r2dt-base) on Docker Hub &rarr;
 
-## R2DT Image
+## Main image
 
-The R2DT image is constructed using the [Dockerfile](https://github.com/r2dt-bio/R2DT/blob/main/Dockerfile) located in the repository's root folder. It inherits from `r2dt-base`.
+The main R2DT image is constructed using the [Dockerfile](https://github.com/r2dt-bio/R2DT/blob/main/Dockerfile) located in the repository's root folder. It inherits from `r2dt-base`.
 
 This approach ensures that the R2DT image remains compact, containing only the Python and R2DT dependencies, excluding the extensive build tools used in the base image. Most changes in the Python code can be made using the prebuilt dependencies and do not require recompilation of C/C++ code.
 
 View [rnacentral/r2dt](https://hub.docker.com/r/rnacentral/r2dt) on Docker Hub &rarr;
 
-## Upgrade Process
+## Upgrade process
 
 When updating the base image, follow these steps:
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -12,6 +12,10 @@ The base image is built using a separate workflow defined in `.github/workflows/
 2. **Set Up Docker**: It sets up Docker Buildx, which is a Docker CLI plugin for extended build capabilities with BuildKit.
 3. **Build and Push**: The base image is built using the instructions in `base_image/Dockerfile` and pushed to a Docker registry.
 
+### Usage of Base Image
+
+The base image serves as a starting point for the main Docker image. It includes essential dependencies and configurations that are common across different builds, ensuring consistency and reducing build times for the resulting images.
+
 ## Building the Resulting Image
 
 The main workflow for building the resulting Docker image is defined in `.github/workflows/main.yml`. This workflow is triggered on pushes and pull requests to the `main` and `develop` branches.
@@ -24,7 +28,21 @@ The main workflow for building the resulting Docker image is defined in `.github
 4. **Comment on Pull Request**: If the workflow is triggered by a pull request, it comments on the PR with the Docker image tags and labels.
 5. **Final Notification**: Sends a Slack notification indicating the completion of the Docker image creation process.
 
-### Parallel Builds
+### Parallel Builds in Dockerfile
+
+The `Dockerfile` supports parallel builds by specifying multiple stages for different components. Each stage is responsible for building a specific part of the application, such as:
+
+- **R-scape**: Installs R-scape, a tool for RNA sequence analysis.
+- **tRNAScan-SE**: Installs tRNAScan-SE, a tool for identifying tRNA genes.
+- **Bio-Easel**: Installs Bio-Easel, a library for biological sequence analysis.
+- **Traveler**: Installs Traveler, a tool for RNA structure visualization.
+- **Scripts**: Installs various scripts for RNA analysis.
+- **Ribovore-Infernal-Easel**: Installs Ribovore and Infernal, tools for RNA sequence analysis.
+- **RNArtist**: Installs RNArtist, a tool for RNA structure visualization.
+
+These stages are combined in the final build stage to create a comprehensive Docker image that includes all necessary tools and dependencies.
+
+### Parallel Builds in Main Workflow
 
 The main workflow supports parallel builds for multiple platforms using Docker Buildx. This allows the resulting Docker image to be compatible with different architectures, enhancing its usability across various environments.
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,0 +1,31 @@
+# GitHub Actions for Docker Image Builds
+
+This document explains how GitHub Actions are used in this project to automate the building and pushing of Docker images. The project uses two main workflows: one for building the base image and another for building the resulting image.
+
+## Building the Base Image
+
+The base image is built using a separate workflow defined in `.github/workflows/base-image.yml`. This workflow is responsible for creating a foundational Docker image that other images can build upon. The base image is defined in `base_image/Dockerfile`.
+
+### Key Steps in Base Image Workflow
+
+1. **Checkout Code**: The workflow checks out the code from the repository to access the Dockerfile and any necessary scripts.
+2. **Set Up Docker**: It sets up Docker Buildx, which is a Docker CLI plugin for extended build capabilities with BuildKit.
+3. **Build and Push**: The base image is built using the instructions in `base_image/Dockerfile` and pushed to a Docker registry.
+
+## Building the Resulting Image
+
+The main workflow for building the resulting Docker image is defined in `.github/workflows/main.yml`. This workflow is triggered on pushes and pull requests to the `main` and `develop` branches.
+
+### Key Steps in Main Workflow
+
+1. **Initial Notification**: Sends a Slack notification indicating the start of the Docker image creation process.
+2. **Create Docker Tag**: Uses the Docker metadata action to generate tags for the Docker image based on the branch or tag being built.
+3. **Build and Push**: Builds the Docker image using `Dockerfile` and pushes it to the Docker registry. This step supports parallel builds for different platforms (e.g., `linux/amd64`, `linux/arm64`).
+4. **Comment on Pull Request**: If the workflow is triggered by a pull request, it comments on the PR with the Docker image tags and labels.
+5. **Final Notification**: Sends a Slack notification indicating the completion of the Docker image creation process.
+
+### Parallel Builds
+
+The main workflow supports parallel builds for multiple platforms using Docker Buildx. This allows the resulting Docker image to be compatible with different architectures, enhancing its usability across various environments.
+
+By automating these processes with GitHub Actions, the project ensures consistent and efficient Docker image builds, reducing manual effort and potential errors.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,16 +1,14 @@
 # GitHub Actions for Docker Image Builds
 
-This document explains how GitHub Actions are used in this project to automate the building and pushing of Docker images. The project uses two main workflows: one for building the base image and another for building the resulting image.
+R2DT automates the building and deployment of Docker images using **GitHub Actions**. The project employs two primary workflows:
+	1.	Base Image Workflow – Creates a foundational Docker image.
+	2.	Main Workflow – Builds the final image using the base image.
+
+This automation streamlines development, ensuring consistency, reducing build times, and minimising manual intervention.
 
 ## Building the Base Image
 
-The base image is built using a separate workflow defined in `.github/workflows/base-image.yml`. This workflow is responsible for creating a foundational Docker image that other images can build upon. The base image is defined in `base_image/Dockerfile`.
-
-### Key Steps in Base Image Workflow
-
-1. **Checkout Code**: The workflow checks out the code from the repository to access the Dockerfile and any necessary scripts.
-2. **Set Up Docker**: It sets up Docker Buildx, which is a Docker CLI plugin for extended build capabilities with BuildKit.
-3. **Build and Push**: The base image is built using the instructions in `base_image/Dockerfile` and pushed to a Docker registry.
+The base image is created via the workflow defined in [parallel-base-image.yml](https://github.com/r2dt-bio/R2DT/blob/main/.github/workflows/parallel-base-image.yml). This workflow provides a standardised environment for subsequent images. The image layers are built in parallel using [BuildJet](https://buildjet.com) and pushed to Docker Hub for caching.
 
 ### Usage of Base Image
 
@@ -18,7 +16,7 @@ The base image serves as a starting point for the main Docker image. It includes
 
 ## Building the Resulting Image
 
-The main workflow for building the resulting Docker image is defined in `.github/workflows/main.yml`. This workflow is triggered on pushes and pull requests to the `main` and `develop` branches.
+The main workflow for building the resulting Docker image is defined in [main.yml](https://github.com/r2dt-bio/R2DT/blob/main/.github/workflows/main.yml). This workflow is triggered on pushes and pull requests to the `main` and `develop` branches.
 
 ### Key Steps in Main Workflow
 
@@ -30,17 +28,13 @@ The main workflow for building the resulting Docker image is defined in `.github
 
 ### Parallel Builds in Dockerfile
 
-The `Dockerfile` supports parallel builds by specifying multiple stages for different components. Each stage is responsible for building a specific part of the application, such as:
+The `Dockerfile` supports parallel builds by specifying multiple stages for different components. Each stage is responsible for building a specific part of the application, for example:
 
-- **R-scape**: Installs R-scape, a tool for RNA sequence analysis.
 - **tRNAScan-SE**: Installs tRNAScan-SE, a tool for identifying tRNA genes.
-- **Bio-Easel**: Installs Bio-Easel, a library for biological sequence analysis.
 - **Traveler**: Installs Traveler, a tool for RNA structure visualization.
-- **Scripts**: Installs various scripts for RNA analysis.
 - **Ribovore-Infernal-Easel**: Installs Ribovore and Infernal, tools for RNA sequence analysis.
-- **RNArtist**: Installs RNArtist, a tool for RNA structure visualization.
 
-These stages are combined in the final build stage to create a comprehensive Docker image that includes all necessary tools and dependencies.
+These stages are combined in the final build stage to create a comprehensive Docker image that includes all the necessary tools and dependencies.
 
 ### Parallel Builds in Main Workflow
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,32 +1,31 @@
-# GitHub Actions for Docker Image Builds
+# GitHub Actions
 
-R2DT automates the building and deployment of Docker images using **GitHub Actions**. The project employs two primary workflows:
-	1.	Base Image Workflow – Creates a foundational Docker image.
-	2.	Main Workflow – Builds the final image using the base image.
+R2DT automates the building and deployment of [Docker images](./docker.md) using **GitHub Actions**. The project employs two primary workflows:
+
+1.	Base Image Workflow – Creates a foundational Docker image.
+2.	Main Workflow – Builds the final image using the base image.
 
 This automation streamlines development, ensuring consistency, reducing build times, and minimising manual intervention.
 
-## Building the Base Image
-
-The base image is created via the workflow defined in [parallel-base-image.yml](https://github.com/r2dt-bio/R2DT/blob/main/.github/workflows/parallel-base-image.yml). This workflow provides a standardised environment for subsequent images. The image layers are built in parallel using [BuildJet](https://buildjet.com) and pushed to Docker Hub for caching.
-
-### Usage of Base Image
+## Base image
 
 The base image serves as a starting point for the main Docker image. It includes essential dependencies and configurations that are common across different builds, ensuring consistency and reducing build times for the resulting images.
 
-## Building the Resulting Image
+The base image is created via the workflow defined in [parallel-base-image.yml](https://github.com/r2dt-bio/R2DT/blob/main/.github/workflows/parallel-base-image.yml). This workflow provides a standardised environment for subsequent images. The image layers are built in parallel using [BuildJet](https://buildjet.com) and pushed to Docker Hub for caching.
+
+## Main image
 
 The main workflow for building the resulting Docker image is defined in [main.yml](https://github.com/r2dt-bio/R2DT/blob/main/.github/workflows/main.yml). This workflow is triggered on pushes and pull requests to the `main` and `develop` branches.
 
-### Key Steps in Main Workflow
+### Key steps
 
-1. **Initial Notification**: Sends a Slack notification indicating the start of the Docker image creation process.
-2. **Create Docker Tag**: Uses the Docker metadata action to generate tags for the Docker image based on the branch or tag being built.
-3. **Build and Push**: Builds the Docker image using `Dockerfile` and pushes it to the Docker registry. This step supports parallel builds for different platforms (e.g., `linux/amd64`, `linux/arm64`).
-4. **Comment on Pull Request**: If the workflow is triggered by a pull request, it comments on the PR with the Docker image tags and labels.
-5. **Final Notification**: Sends a Slack notification indicating the completion of the Docker image creation process.
+1. **Initial notification**: Sends a Slack notification indicating the start of the Docker image creation process.
+2. **Create Docker tag**: Uses the Docker metadata action to generate tags for the Docker image based on the branch or tag being built.
+3. **Build and push**: Builds the Docker image using `Dockerfile` and pushes it to the Docker registry. This step supports parallel builds for different platforms (e.g., `linux/amd64`, `linux/arm64`).
+4. **Comment on pull request**: If the workflow is triggered by a pull request, it comments on the PR with the Docker image tags and labels.
+5. **Final notification**: Sends a Slack notification indicating the completion of the Docker image creation process.
 
-### Parallel Builds in Dockerfile
+### Parallel builds in Dockerfile
 
 The `Dockerfile` supports parallel builds by specifying multiple stages for different components. Each stage is responsible for building a specific part of the application, for example:
 
@@ -36,7 +35,7 @@ The `Dockerfile` supports parallel builds by specifying multiple stages for diff
 
 These stages are combined in the final build stage to create a comprehensive Docker image that includes all the necessary tools and dependencies.
 
-### Parallel Builds in Main Workflow
+### Parallel builds in main workflow
 
 The main workflow supports parallel builds for multiple platforms using Docker Buildx. This allows the resulting Docker image to be compatible with different architectures, enhancing its usability across various environments.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,6 +108,7 @@ If you have any questions or feedback, feel free to [submit a GitHub issue](http
    docs
    testing
    docker
+   github-actions
    releases
 ```
 


### PR DESCRIPTION
Added some documentation on github actions. Please suggest where a link to the file would be appropriate.