### PR TITLE
Refactor path handling to use pathlib in generate_model_info.py

### DIFF
--- a/utils/generate_model_info.py
+++ b/utils/generate_model_info.py
@@ -12,10 +12,9 @@ limitations under the License.
 """
 
 
-import glob
-import os
 import re
 import shutil
+from pathlib import Path
 
 from . import rfam
 
@@ -23,20 +22,21 @@ from . import rfam
 def allowed_names(cm_library):
     """Return all model names and CM paths
     for a given template library."""
-    for cm_file in glob.glob(os.path.join(cm_library, "*.cm")):
+    cm_library = Path(cm_library)
+    for cm_file in cm_library.glob("*.cm"):
         model_name = None
-        if "all.cm" in cm_file:
+        if cm_file.name == "all.cm":
             continue
-        if re.search(r"RF\d{5}", cm_file):
-            rfam_acc = os.path.basename(cm_file).replace(".cm", "")
+        if re.search(r"RF\d{5}", str(cm_file)):
+            rfam_acc = cm_file.stem  # removes .cm
             if rfam_acc in rfam.BLACKLIST:
                 continue
-            with open(cm_file, "r", encoding="utf-8") as f_cm:
+            with cm_file.open("r", encoding="utf-8") as f_cm:
                 for line in f_cm:
                     if line.startswith("NAME "):
                         model_name = line.strip().split()[-1]
         else:
-            model_name = os.path.basename(cm_file).replace(".cm", "")
+            model_name = cm_file.stem
         if not model_name:
             raise ValueError(f"Could not find model_name for {cm_file}")
         yield (model_name, cm_file)
@@ -45,21 +45,22 @@ def allowed_names(cm_library):
 def generate_model_info(cm_library, rna_type="SSU"):
     """Generate a model info file listing all covariance models
     for a given template library."""
-    if not os.path.exists(cm_library):
-        raise ValueError("Missing CM directory: " + cm_library)
+    cm_library = Path(cm_library)
+    if not cm_library.exists():
+        raise ValueError("Missing CM directory: " + str(cm_library))
     print(f"Processing files in {cm_library}")
 
-    all_cm_path = os.path.join(cm_library, "all.cm")
-    modelinfo = os.path.join(cm_library, "modelinfo.txt")
+    all_cm_path = cm_library / "all.cm"
+    modelinfo = cm_library / "modelinfo.txt"
 
-    with open(all_cm_path, "w", encoding="utf-8") as all_out:
-        with open(modelinfo, "w", encoding="utf-8") as model_out:
+    with all_cm_path.open("w", encoding="utf-8") as all_out:
+        with modelinfo.open("w", encoding="utf-8") as model_out:
             model_out.write("*all*    -    -    all.cm\n")
             for model_name, cm_path in allowed_names(cm_library):
-                with open(cm_path, "r", encoding="utf-8") as cm_file:
+                with cm_path.open("r", encoding="utf-8") as cm_file:
                     shutil.copyfileobj(cm_file, all_out)
                 model_line = "    ".join(
-                    [model_name, rna_type, "Bacteria", os.path.basename(cm_path)]
+                    [model_name, rna_type, "Bacteria", cm_path.name]
                 )
                 model_out.write(f"{model_line}\n")
     print("Done")


### PR DESCRIPTION
This pull request updates the `generate_model_info.py` file to replace the use of the `os` module with `pathlib` for path manipulations. The changes include:

- Replaced `os.path.join` with the `/` operator from `pathlib` for constructing paths.
- Used `Path.glob` for pattern matching instead of `glob.glob`.
- Updated file opening methods to use `Path.open()` instead of the built-in `open()` function.

These changes improve the readability and maintainability of the code by utilizing the more modern `pathlib` library for path operations.

---

> This pull request was co-created with Cosine Genie

Original Task: [R2DT/vyy62m895ohk](https://cosine.sh/e8ods33jna0g/R2DT/task/vyy62m895ohk)
Author: Anton Petrov
